### PR TITLE
Encode the whois result to UTF-8

### DIFF
--- a/src/Phois/Whois/Whois.php
+++ b/src/Phois/Whois/Whois.php
@@ -108,7 +108,10 @@ class Whois {
                     fclose($fp);
                 }
 
-                return htmlspecialchars($string);
+				$string_encoding = mb_detect_encoding($string, "UTF-8, ISO-8859-1, ISO-8859-15", true);
+				$string_utf8 = mb_convert_encoding($string, "UTF-8", $string_encoding);
+
+                return htmlspecialchars($string_utf8, ENT_COMPAT, "UTF-8", true);
             } else {
                 return "No whois server for this tld in list!";
             }


### PR DESCRIPTION
Encode the whois result to UTF-8 as htmlspecialchars() expects UTF-8 by default since PHP 5.4. If the result isn't encoded and it contains latin characters, the htmlspecialchars() output is null. Also force htmlspecialchars() to use UTF-8 for PHP<5.4 compatibility. Test case - query the domain "unihostbrasil.com.br".
