### PR TITLE
Add regex for punycode domain syntax

### DIFF
--- a/src/Phois/Whois/Whois.php
+++ b/src/Phois/Whois/Whois.php
@@ -19,7 +19,10 @@ class Whois
     {
         $this->domain = $domain;
         // check $domain syntax and split full domain name on subdomain and TLDs
-        if (preg_match('/^([\p{L}\d\-]+)\.((?:[\p{L}\-]+\.?)+)$/ui', $this->domain, $matches)) {
+        if (
+            preg_match('/^([\p{L}\d\-]+)\.((?:[\p{L}\-]+\.?)+)$/ui', $this->domain, $matches)
+            || preg_match('/^(xn\-\-[\p{L}\d\-]+)\.(xn\-\-(?:[\p{L}\-]+\.?1?)+)$/ui', $this->domain, $matches)
+        ) {
             $this->subDomain = $matches[1];
             $this->TLDs = $matches[2];
         } else


### PR DESCRIPTION
You added ".рф" to servers.json (https://github.com/regru/php-whois/commit/dd12d083c818975f05d6253eb900139713c4803f#diff-39cd963adac8f759fde4cfa440663efdR1482) but your regex fails to validate. This should fix (also reported https://github.com/regru/php-whois/issues/22)
