### PR TITLE
* Exception message fix

### DIFF
--- a/src/Phois/Whois/Whois.php
+++ b/src/Phois/Whois/Whois.php
@@ -26,7 +26,7 @@ class Whois
             $this->subDomain = $matches[1];
             $this->TLDs = $matches[2];
         } else
-            throw new \InvalidArgumentException('Invalid $domain syntax');
+            throw new \InvalidArgumentException("Invalid $domain syntax");
         // setup whois servers array from json file
         $this->servers = json_decode(file_get_contents( __DIR__.'/whois.servers.json' ), true);
     }


### PR DESCRIPTION
Because if single quotes $domain var wouldn't be passed to Exception.