### PR TITLE
Replace whois.nic.ad.jp with whois.jprs.jp

### DIFF
--- a/src/Phois/Whois/whois.servers.json
+++ b/src/Phois/Whois/whois.servers.json
@@ -32,7 +32,7 @@
         "NOT FOUND"
     ],
     "ac.jp": [
-        "whois.nic.ad.jp",
+        "whois.jprs.jp",
         "No match!!"
     ],
     "ac.ke": [
@@ -592,7 +592,7 @@
         "NOT FOUND"
     ],
     "co.jp": [
-        "whois.nic.ad.jp",
+        "whois.jprs.jp",
         "No match!!"
     ],
     "co.ke": [
@@ -1388,7 +1388,7 @@
         "Not found"
     ],
     "go.jp": [
-        "whois.nic.ad.jp",
+        "whois.jprs.jp",
         "No match!!"
     ],
     "go.kr": [
@@ -2268,7 +2268,7 @@
         "No entries found"
     ],
     "ne.jp": [
-        "whois.nic.ad.jp",
+        "whois.jprs.jp",
         "No match!!"
     ],
     "ne.kr": [
@@ -2524,7 +2524,7 @@
         "nothing found"
     ],
     "or.jp": [
-        "whois.nic.ad.jp",
+        "whois.jprs.jp",
         "No match!!"
     ],
     "or.kr": [


### PR DESCRIPTION
whois.nic.ad.jp doesn't seem to produce any usable result. whois.jprs.jp does.