### PR TITLE
Allow the setting of an override server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+_Forked to introduce some changes needed for our company_
+
 # php-whois
 
 PHP class to retrieve WHOIS information.

--- a/src/Phois/Whois/Whois.php
+++ b/src/Phois/Whois/Whois.php
@@ -11,6 +11,8 @@ class Whois
     private $subDomain;
 
     private $servers;
+    
+    private $overrideServer;
 
     /**
      * @param string $domain full domain name (without trailing dot)
@@ -34,7 +36,10 @@ class Whois
     public function info()
     {
         if ($this->isValid()) {
-            $whois_server = $this->servers[$this->TLDs][0];
+            if($this->overrideServer == '')
+                $whois_server = $this->servers[$this->TLDs][0];
+            else
+                $whois_server = $this->overrideServer;
 
             // If TLDs have been found
             if ($whois_server != '') {
@@ -152,6 +157,11 @@ class Whois
     public function getSubDomain()
     {
         return $this->subDomain;
+    }
+    
+    public function setOverrideServer($overrideServer)
+    {
+        $this->overrideServer = $overrideServer;
     }
 
     public function isAvailable()


### PR DESCRIPTION
This allows the end user to override the server that's used. For me, that's important when the first server is down or is returning incomplete data. This is a completely non-breaking change, it just adds an extra layer of functionality.