### PR TITLE
change ua whois

### DIFF
--- a/src/Phois/Whois/whois.servers.json
+++ b/src/Phois/Whois/whois.servers.json
@@ -736,7 +736,7 @@
         "No Found"
     ],
     "com.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "com.ve": [
@@ -924,7 +924,7 @@
         "not found..."
     ],
     "dn.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "docs": [
@@ -1856,7 +1856,7 @@
         "is available for registration"
     ],
     "kh.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "ki": [
@@ -1864,7 +1864,7 @@
         "Domain Status: No Object Found"
     ],
     "kiev.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "kim": [
@@ -1952,7 +1952,7 @@
         "No match for"
     ],
     "lg.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "lgbt": [
@@ -2028,7 +2028,7 @@
         "Status: free"
     ],
     "lviv.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "ly": [
@@ -2364,7 +2364,7 @@
         "No Found"
     ],
     "net.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "net.uk": [
@@ -2624,7 +2624,7 @@
         "No Found"
     ],
     "org.ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "org.uk": [
@@ -3400,7 +3400,7 @@
         "% No entries found."
     ],
     "ua": [
-        "whois.net.ua",
+        "whois.ua",
         "No entries found"
     ],
     "ug": [


### PR DESCRIPTION
whois.net.ua not work, replace to whois.ua
```
%
%          EUNIC Whois Server (KV).
%      Output is sent in UTF-8 encoding.
% Просьба посетить http://www.coordinator.net.ua
% для получения дополнительной информации.
%

Error: no object found
```