### PR TITLE
Support 15 gTLDs and ccTLDs (.app, .ai, .cloud, ..etc)

### DIFF
--- a/src/Phois/Whois/whois.servers.json
+++ b/src/Phois/Whois/whois.servers.json
@@ -1,4 +1,64 @@
 {
+    "app": [
+        "whois.nic.google",
+        "Domain not found."
+    ],
+    "run": [
+        "whois.nic.run",
+        "available"
+    ],
+    "plus": [
+        "whois.nic.plus",
+        "available"
+    ],
+    "ai": [
+        "whois.nic.ai",
+        "available"
+    ],
+    "live": [
+        "whois.nic.live",
+        "available"
+    ],
+    "vip": [
+        "whois.nic.vip",
+        "available"
+    ],
+    "studio": [
+        "whois.nic.studio",
+        "available"
+    ],
+    "group": [
+        "whois.nic.group",
+        "available"
+    ],
+    "storage": [
+        "whois.nic.storage",
+        "available"
+    ],
+    "date": [
+        "whois.nic.date",
+        "No Data Found"
+    ],
+    "ist": [
+        "whois.afilias-srs.net",
+        "NOT FOUND"
+    ],
+    "fan": [
+        "whois.nic.fan",
+        "Domain not found."
+    ],
+    "film": [
+        "whois.nic.film",
+        "No Data Found"
+    ],
+    "cloud": [
+        "whois.nic.cloud",
+        "No Data Found"
+    ],
+    "shop": [
+        "whois.nic.shop",
+        "The queried object does not exist: DOMAIN NOT FOUND"
+    ],
     "abogado": [
         "whois-dub.mm-registry.com",
         "is available for registration"


### PR DESCRIPTION
Depend on IANA data I'm gonna add some whois server details for:

```
.app
.run
.plus
.ai
.live
.vip
.studio
.group
.storage
.date
.ist
.fan
.film
.cloud
.shop
```

Whois servers details have been copied from this source:
https://www.iana.org/domains/root/db/app.html

Except for the `.shop` there was no specific information about the whois server. But I found the whois server.